### PR TITLE
Added 1 to all Indices Properties in ConnectionTester UI

### DIFF
--- a/Source/Tools/PMUConnectionTester/PMUConnectionTester/PMUConnectionTester.cs
+++ b/Source/Tools/PMUConnectionTester/PMUConnectionTester/PMUConnectionTester.cs
@@ -3007,6 +3007,10 @@ public partial class PMUConnectionTester
 
             row["Attribute"] = $"     {attribute.Key}";
             row["Value"] = attribute.Value;
+
+            // Indices should start at 0
+            if (string.Equals(attribute.Key, "Index"))
+                row["Value"] = (int.Parse(attribute.Value) + 1).ToString();
             row["ChannelNode"] = 0;
 
             attributeTable.Rows.Add(row);


### PR DESCRIPTION
This fixes the Connection Tester user interface under ConnectionSpecific -> PhasorIndex
Since Indices in C37.118 are 1 based but in the code they are 0 based.

Related to: PDC-12
